### PR TITLE
Release 1.1.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,0 @@
----
-fixtures:
-  repositories:
-    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-  symlinks:
-    cron: "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v1.1.0](https://github.com/voxpupuli/puppet-cron/tree/v1.1.0) (2018-01-19)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-cron/compare/v1.0.0...v1.1.0)
+
+**Fixed bugs:**
+
+- Fix hiera lookup regression [\#40](https://github.com/voxpupuli/puppet-cron/pull/40) ([alexjfisher](https://github.com/alexjfisher))
+
+**Merged pull requests:**
+
+- Voxpupuli migration [\#37](https://github.com/voxpupuli/puppet-cron/pull/37) ([alexjfisher](https://github.com/alexjfisher))
+
 ## v1.0.0 (2017-10-14)
 
   * BREAKING: Require Puppet version >=4.9.1

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-cron",
-  "version": "1.1.0-rc0",
+  "version": "1.1.0",
   "author": "Vox Pupuli",
   "summary": "Module to manage cron jobs via /etc/cron.d/",
   "license": "Apache-2.0",


### PR DESCRIPTION
Supercedes https://github.com/voxpupuli/puppet-cron/pull/38

Changelog has been regenerated.