### PR TITLE
templates already add '@' for specials

### DIFF
--- a/types/special.pp
+++ b/types/special.pp
@@ -1,12 +1,12 @@
 # Valid $special parameter to Cron::Job.
 type Cron::Special = Optional[
-  Enum['@annually',
-       '@daily',
-       '@hourly',
-       '@midnight',
-       '@monthly',
-       '@reboot',
-       '@weekly',
-       '@yearly',
+  Enum['annually',
+       'daily',
+       'hourly',
+       'midnight',
+       'monthly',
+       'reboot',
+       'weekly',
+       'yearly',
   ]
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
with current version you will get
@@reboot ...
if you use
special => '@reboot'

#### This Pull Request (PR) fixes the following issues
One @-sign should be enough :)