### PR TITLE
Fix `job::cron` `special` parameter

### DIFF
--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -146,4 +146,18 @@ describe 'cron::job' do
       end
     end
   end
+
+  context 'job with special parameter set' do
+    let(:params) do
+      {
+        command: '/usr/bin/sleep 10',
+        special: 'reboot'
+      }
+    end
+
+    it do
+      is_expected.to compile
+      is_expected.to contain_file("job_#{title}").with_content(%r{^@reboot root /usr/bin/sleep 10$})
+    end
+  end
 end

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -17,8 +17,8 @@
 <% if @description -%>
 # <%= @description %>
 <% end -%>
-<%- if @special.nil? -%>
+<%- unless @special -%>
 <%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %>  <%= @command %>
 <%  else -%>
-@<%= @special %>  <%= @user %>  <%= @command %>
+@<%= @special %> <%= @user %> <%= @command %>
 <%  end -%>

--- a/types/special.pp
+++ b/types/special.pp
@@ -1,12 +1,12 @@
 # Valid $special parameter to Cron::Job.
 type Cron::Special = Optional[
-  Enum['@annually',
-       '@daily',
-       '@hourly',
-       '@midnight',
-       '@monthly',
-       '@reboot',
-       '@weekly',
-       '@yearly',
+  Enum['annually',
+       'daily',
+       'hourly',
+       'midnight',
+       'monthly',
+       'reboot',
+       'weekly',
+       'yearly',
   ]
 ]


### PR DESCRIPTION
Cherry-picks fix from https://github.com/voxpupuli/puppet-cron/pull/54 and adds test.

@ekohl I think fixing the validation is correct compared to fixing the template, since there's no way the 'new' API ever actually worked.

NB.  Creating this PR from a branch pushed to the main voxpupuli fork as github kept exploding with a 500 error when trying to create the same PR from my fork.