### PR TITLE
add merge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,6 @@ You can also specify a different cron package name via `package_name`.
 By default we try to select the right one for your distribution.
 But in some cases (e.g. Gentoo) you might want to overwrite it here.
 
-This class allows specifying the following parameter:
-
-   * `manage_package` - optional - defaults to "true"
-   * `package_ensure` - optional - defaults to "installed"
-   * `package_name`   - optional - defaults to OS specific default package name
-   * `service_name`   - optional - defaults to OS specific default service name
-   * `manage_service`   - optional - defaults to "true"
-   * `service_enable`   - optional - defaults to "true"
-   * `service_ensure`   - optional - defaults to "running"
-   * `manage_users_allow` - optional - defaults to false, whether to manage `/etc/cron.allow`
-   * `manage_users_deny` - optional - defaults to false, whether to manage `/etc/cron.deny`
-   * `users_allow` - optional - An array of users to add to `/etc/cron.allow`
-   * `users_deny` - optional - An array of users to add to `/etc/cron.deny`
-
-
 Examples:
 
 ```puppet

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,7 @@ The following parameters are available in the `cron` class:
 * [`users_deny`](#users_deny)
 * [`manage_users_allow`](#manage_users_allow)
 * [`manage_users_deny`](#manage_users_deny)
+* [`merge`](#merge)
 * [`package_ensure`](#package_ensure)
 
 ##### <a name="service_name"></a>`service_name`
@@ -155,6 +156,14 @@ Data type: `Boolean`
 If the /etc/cron.deny should be managed.
 
 Default value: ``false``
+
+##### <a name="merge"></a>`merge`
+
+Data type: `Enum['deep', 'first', 'hash', 'unique']`
+
+The `lookup()` merge method to use with cron job hiera lookups.
+
+Default value: `'hash'`
 
 ##### <a name="package_ensure"></a>`package_ensure`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 # @param users_deny A list of users which are prohibited from create, edit, display, or remove crontab files. Only used if manage_users_deny == true.
 # @param manage_users_allow If the /etc/cron.allow should be managed.
 # @param manage_users_deny If the /etc/cron.deny should be managed.
+# @param merge The `lookup()` merge method to use with cron job hiera lookups.
 # @example
 #  include cron
 # @example
@@ -27,6 +28,7 @@ class cron (
   Array[Cron::User]    $users_deny         = [],
   Boolean              $manage_users_allow = false,
   Boolean              $manage_users_deny  = false,
+  Enum['deep', 'first', 'hash', 'unique'] $merge = 'hash',
 ) {
   contain 'cron::install'
   contain 'cron::service'
@@ -56,42 +58,42 @@ class cron (
 
   # Create jobs from hiera
 
-  $cron_job = lookup('cron::job', Optional[Hash], 'hash', {})
+  $cron_job = lookup('cron::job', Optional[Hash], $merge, {})
   $cron_job.each | String $t, Hash $params | {
     cron::job { $t:
       * => $params,
     }
   }
 
-  $cron_job_multiple = lookup('cron::job::multiple', Optional[Hash], 'hash', {})
+  $cron_job_multiple = lookup('cron::job::multiple', Optional[Hash], $merge, {})
   $cron_job_multiple.each | String $t, Hash $params | {
     cron::job::multiple { $t:
       * => $params,
     }
   }
 
-  $cron_hourly = lookup('cron::hourly', Optional[Hash], 'hash', {})
+  $cron_hourly = lookup('cron::hourly', Optional[Hash], $merge, {})
   $cron_hourly.each | String $t, Hash $params | {
     cron::hourly { $t:
       * => $params,
     }
   }
 
-  $cron_daily = lookup('cron::daily', Optional[Hash], 'hash', {})
+  $cron_daily = lookup('cron::daily', Optional[Hash], $merge, {})
   $cron_daily.each | String $t, Hash $params | {
     cron::daily { $t:
       * => $params,
     }
   }
 
-  $cron_weekly = lookup('cron::weekly', Optional[Hash], 'hash', {})
+  $cron_weekly = lookup('cron::weekly', Optional[Hash], $merge, {})
   $cron_weekly.each | String $t, Hash $params | {
     cron::weekly { $t:
       * => $params,
     }
   }
 
-  $cron_monthly = lookup('cron::monthly', Optional[Hash], 'hash', {})
+  $cron_monthly = lookup('cron::monthly', Optional[Hash], $merge, {})
   $cron_monthly.each | String $t, Hash $params | {
     cron::monthly { $t:
       * => $params,

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -144,4 +144,15 @@ describe 'cron' do
       )
     }
   end
+
+  context 'merge => deep' do
+    let(:params) do
+      {
+        merge: 'deep',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('cron').with_merge('deep') }
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Add `merge` option to enable to use other methods (`first`, `unique` or `deep`) than `hash`.

Default is set as `hash` as same as current behavior.

