### PR TITLE
Changes the defaults of the cronjob-files from 644 to 600

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It allows specifying the following parameters:
   * `special`     - optional - defaults to undef
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
   * `description` - optional - defaults to undef
 
 Example:
@@ -141,7 +141,7 @@ It allows specifying the following parameters:
   * `ensure`      - optional - defaults to "present"
   * `jobs`        - required - an array of hashes of multiple cron jobs using a similar structure as `cron::job`-parameters
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
 
 And the keys of the jobs hash are:
 
@@ -234,7 +234,7 @@ It allows specifying the following parameters:
   * `minute`      - optional - defaults to "0"
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
   * `description` - optional - defaults to undef
 
 Example:
@@ -274,7 +274,7 @@ It allows specifying the following parameters:
   * `hour`        - optional - defaults to "0"
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
   * `description` - optional - defaults to undef
 
 Example:
@@ -314,7 +314,7 @@ It allows specifying the following parameters:
   * `weekday`     - optional - defaults to "0"
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
   * `description` - optional - defaults to undef
 
 Example:
@@ -356,7 +356,7 @@ It allows specifying the following parameters:
   * `date`        - optional - defaults to "1"
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
-  * `mode`        - optional - defaults to "0644"
+  * `mode`        - optional - defaults to "0600"
   * `description` - optional - defaults to undef
 
 Example:

--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -16,7 +16,7 @@
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
-#     Defaults to 0644.
+#     Defaults to 0600.
 #   description - Optional short description, which will be included in the
 #   cron job file.
 #     Defaults to undef.
@@ -41,7 +41,7 @@ define cron::daily (
   Cron::Hour          $hour        = 0,
   Cron::Environment   $environment = [],
   Cron::User          $user        = 'root',
-  Cron::Mode          $mode        = '0644',
+  Cron::Mode          $mode        = '0600',
   Optional[String]    $description = undef,
 ) {
 

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -11,7 +11,7 @@
 #   environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file.
-#     Defaults to 0644.
+#     Defaults to 0600.
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   description - Optional short description, which will be included in the
@@ -36,7 +36,7 @@ define cron::hourly (
   Cron::Minute        $minute      = 0,
   Cron::Environment   $environment = [],
   Cron::User          $user        = 'root',
-  Cron::Mode          $mode        = '0644',
+  Cron::Mode          $mode        = '0600',
   Optional[String]    $description = undef,
 ) {
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -23,7 +23,7 @@
 #   environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file
-#     Defaults to 0644.
+#     Defaults to 0600.
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   description - Optional short description, which will be included in the
@@ -53,7 +53,7 @@ define cron::job (
   Cron::Special       $special     = undef,
   Cron::Environment   $environment = [],
   Cron::User          $user        = 'root',
-  Cron::Mode          $mode        = '0644',
+  Cron::Mode          $mode        = '0600',
   Optional[String]    $description = undef,
 ) {
 

--- a/manifests/job/multiple.pp
+++ b/manifests/job/multiple.pp
@@ -10,7 +10,7 @@
 #   environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file
-#     Defaults to 0644.
+#     Defaults to 0600.
 #
 # Sample Usage:
 #
@@ -56,7 +56,7 @@ define cron::job::multiple(
   }]]               $jobs,
   Cron::Job_ensure  $ensure      = 'present',
   Cron::Environment $environment = [],
-  Cron::Mode        $mode        = '0644',
+  Cron::Mode        $mode        = '0600',
 ) {
   case $ensure {
     'absent': {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -19,7 +19,7 @@
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
-#     Defaults to 0644.
+#     Defaults to 0600.
 #   description - Optional short description, which will be included in the
 #   cron job file.
 #     Defaults to undef.
@@ -46,7 +46,7 @@ define cron::monthly (
   Cron::Date          $date        = 1,
   Cron::Environment   $environment = [],
   Cron::User          $user        = 'root',
-  Cron::Mode          $mode        = '0644',
+  Cron::Mode          $mode        = '0600',
   Optional[String]    $description = undef,
 ) {
 

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -19,7 +19,7 @@
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
-#     Defaults to '0640'.
+#     Defaults to '0600'.
 #   description - Optional short description, which will be included in the
 #   cron job file.
 #     Defaults to undef.
@@ -45,7 +45,7 @@ define cron::weekly (
   Cron::Hour          $hour        = 0,
   Cron::Weekday       $weekday     = 0,
   Cron::User          $user        = 'root',
-  Cron::Mode          $mode        = '0644',
+  Cron::Mode          $mode        = '0600',
   Cron::Environment   $environment = [],
   Optional[String]    $description = undef,
 ) {

--- a/spec/defines/daily_spec.rb
+++ b/spec/defines/daily_spec.rb
@@ -19,7 +19,7 @@ describe 'cron::daily' do
       'weekday'     => '*',
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
-      'mode'        => params[:mode] || '0644',
+      'mode'        => params[:mode] || '0600',
       'command'     => params[:command]
     )
   end

--- a/spec/defines/hourly_spec.rb
+++ b/spec/defines/hourly_spec.rb
@@ -18,7 +18,7 @@ describe 'cron::hourly' do
       'weekday'     => '*',
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
-      'mode'        => params[:mode] || '0644',
+      'mode'        => params[:mode] || '0600',
       'command'     => params[:command]
     )
   end

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -76,7 +76,7 @@ describe 'cron::job' do
         'ensure'  => 'file',
         'owner'   => 'root',
         'group'   => 'root',
-        'mode'    => '0644',
+        'mode'    => '0600',
         'path'    => "/etc/cron.d/#{title}"
       ).with_content(
         %r{\n#{cron_timestamp}\s+}
@@ -96,7 +96,7 @@ describe 'cron::job' do
         weekday: '*',
         environment: ['MAILTO="root"', 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"'],
         user: 'admin',
-        mode: '0644',
+        mode: '0600',
         description: 'Mysql backup',
         command: 'mysqldump -u root test_db >some_file'
       }

--- a/spec/defines/monthly_spec.rb
+++ b/spec/defines/monthly_spec.rb
@@ -20,7 +20,7 @@ describe 'cron::monthly' do
       'weekday'     => '*',
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
-      'mode'        => params[:mode] || '0644',
+      'mode'        => params[:mode] || '0600',
       'command'     => params[:command]
     )
   end

--- a/spec/defines/weekly_spec.rb
+++ b/spec/defines/weekly_spec.rb
@@ -20,7 +20,7 @@ describe 'cron::weekly' do
       'weekday'     => params[:weekday],
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
-      'mode'        => params[:mode] || '0644',
+      'mode'        => params[:mode] || '0600',
       'command'     => params[:command]
     )
   end


### PR DESCRIPTION
In order to comply with CIS Benchmark Requirements
(#65) the file-mode of all files has been changed
from 644 to 600. The files should only be readable
by root. For CIS-benchmark see:
https://www.cisecurity.org/cis-benchmarks/

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
