### PR TITLE
Adjust cron.allow / cron.deny permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class cron (
   if $manage_users_allow {
     file { '/etc/cron.allow':
       ensure  => file,
+      mode    => '0644',
       owner   => 'root',
       group   => 'root',
       content => epp('cron/users.epp', { 'users' => $users_allow }),
@@ -65,6 +66,7 @@ class cron (
   if $manage_users_deny {
     file { '/etc/cron.deny':
       ensure  => file,
+      mode    => '0644',
       owner   => 'root',
       group   => 'root',
       content => epp('cron/users.epp', { 'users' => $users_deny }),


### PR DESCRIPTION
Hi people,

#### Pull Request (PR) description

In order to set the permissions for cron.allow / cron.deny accordingly I adjusted the two file statements. According to the `crontab` docs, its necessary to set the permissons to "world readable" 

```
FILES
       /etc/cron.allow
       /etc/cron.deny
       /var/spool/cron/crontabs

       The files /etc/cron.allow and /etc/cron.deny if, they exist, must be either world-readable, or readable by group ``crontab''. If they are not, then cron will deny access to all users until the permissions are fixed.
```
