### PR TITLE
Make the mode a parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -50,13 +50,13 @@ This class wraps *cron::install* for ease of use
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 include cron
 ```
 
-##### 
+#####
 
 ```puppet
 class { 'cron':
@@ -78,6 +78,7 @@ The following parameters are available in the `cron` class:
 * [`users_deny`](#users_deny)
 * [`manage_users_allow`](#manage_users_allow)
 * [`manage_users_deny`](#manage_users_deny)
+* [`allow_deny_mode`](#allow_deny_mode)
 * [`merge`](#merge)
 * [`package_ensure`](#package_ensure)
 
@@ -157,6 +158,14 @@ If the /etc/cron.deny should be managed.
 
 Default value: ``false``
 
+##### <a name="allow_deny_mode"></a>`allow_deny_mode`
+
+Data type: `Cron::Mode`
+
+Specify the cron.allow/deny file mode
+
+Default value: ``0644``
+
 ##### <a name="merge"></a>`merge`
 
 Data type: `Enum['deep', 'first', 'hash', 'unique']`
@@ -189,7 +198,7 @@ This type creates a daily cron job via a file in /etc/cron.d
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::daily { 'mysql_backup':
@@ -283,7 +292,7 @@ This type creates an hourly cron job via a file in /etc/cron.d
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::hourly { 'generate_puppetdoc':
@@ -367,7 +376,7 @@ This type creates a cron job via a file in /etc/cron.d
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::job { 'generate_puppetdoc':
@@ -496,7 +505,7 @@ This type creates multiple cron jobs via a single file in /etc/cron.d/
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::job::multiple { 'test':
@@ -578,7 +587,7 @@ This type creates a monthly cron job via a file in /etc/cron.d
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::monthly { 'delete_old_log_files':
@@ -682,7 +691,7 @@ This type creates a cron job via a file in /etc/cron.d
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 cron::weekly { 'delete_old_temp_files':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class cron (
   Array[Cron::User]    $users_deny         = [],
   Boolean              $manage_users_allow = false,
   Boolean              $manage_users_deny  = false,
+  String               $mode               = '0640',
   Enum['deep', 'first', 'hash', 'unique'] $merge = 'hash',
 ) {
   contain 'cron::install'
@@ -39,7 +40,7 @@ class cron (
   if $manage_users_allow {
     file { '/etc/cron.allow':
       ensure  => file,
-      mode    => '0644',
+      mode    => $mode,
       owner   => 'root',
       group   => 0,
       content => epp('cron/users.epp', { 'users' => $users_allow }),
@@ -49,7 +50,7 @@ class cron (
   if $manage_users_deny {
     file { '/etc/cron.deny':
       ensure  => file,
-      mode    => '0644',
+      mode    => $mode,
       owner   => 'root',
       group   => 0,
       content => epp('cron/users.epp', { 'users' => $users_deny }),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 # @param users_deny A list of users which are prohibited from create, edit, display, or remove crontab files. Only used if manage_users_deny == true.
 # @param manage_users_allow If the /etc/cron.allow should be managed.
 # @param manage_users_deny If the /etc/cron.deny should be managed.
+# @param allow_deny_mode Specify the cron.allow/deny file mode.
 # @param merge The `lookup()` merge method to use with cron job hiera lookups.
 # @example
 #  include cron
@@ -28,7 +29,7 @@ class cron (
   Array[Cron::User]    $users_deny         = [],
   Boolean              $manage_users_allow = false,
   Boolean              $manage_users_deny  = false,
-  String               $mode               = '0640',
+  Cron::Mode           $allow_deny_mode    = '0644',
   Enum['deep', 'first', 'hash', 'unique'] $merge = 'hash',
 ) {
   contain 'cron::install'
@@ -40,7 +41,7 @@ class cron (
   if $manage_users_allow {
     file { '/etc/cron.allow':
       ensure  => file,
-      mode    => $mode,
+      mode    => $allow_deny_mode,
       owner   => 'root',
       group   => 0,
       content => epp('cron/users.epp', { 'users' => $users_allow }),
@@ -50,7 +51,7 @@ class cron (
   if $manage_users_deny {
     file { '/etc/cron.deny':
       ensure  => file,
-      mode    => $mode,
+      mode    => $allow_deny_mode,
       owner   => 'root',
       group   => 0,
       content => epp('cron/users.epp', { 'users' => $users_deny }),


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Make the mode for cron.allow/deny files a parameter as compliance framework like CIS ask the file to be 0640 maximum
