### PR TITLE
Update multiple.pp

### DIFF
--- a/manifests/job/multiple.pp
+++ b/manifests/job/multiple.pp
@@ -54,7 +54,7 @@ define cron::job::multiple (
       file { "job_${title}":
         ensure  => $ensure,
         owner   => 'root',
-        group   => 'root',
+        group   => 0,
         mode    => $mode,
         path    => "/etc/cron.d/${title}",
         content => template('cron/multiple.erb'),


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
FreeBSD cannot handle group called root, but it can be handle group number 0

#### This Pull Request (PR) fixes the following issues
Error: Could not set 'directory' on ensure: Could not find group root (file: /etc/puppetlabs/code/environments/development/modules/logrotate/manifests/hourly.pp, line: 27)
Error: Could not set 'directory' on ensure: Could not find group root (file: /etc/puppetlabs/code/environments/development/modules/logrotate/manifests/hourly.pp, line: 27)
Wrapped exception:
Could not find group root
Error: /Stage[main]/Logrotate::Hourly/File[/usr/local/etc/logrotate.d/hourly]/ensure: change from 'absent' to 'directory' failed: Could not set 'directory' on ensure: Could not find group root (file: /etc/puppetlabs/code/environments/development/modules/logrotate/manifests/hourly.pp, line: 27)
