### PR TITLE
Drop support for EL7 as it is end of life

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -22,7 +21,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -39,12 +37,6 @@
       "operatingsystemrelease": [
         "8",
         "9"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -153,21 +153,6 @@ describe 'cron' do
                           ])
         }
 
-        if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i == 6
-          context 'on rhel 6' do
-            it {
-              verify_contents(catalogue, '/etc/crontab',
-                              [
-                                'SHELL=/bin/bash',
-                                'PATH=/sbin:/bin:/usr/sbin:/usr/bin',
-                                'MAILTO=root',
-                                'HOME=/',
-                                '# For details see man 4 crontabs'
-                              ])
-            }
-          end
-        end
-
         context 'crontab_run_parts defined' do
           let(:params) do
             {


### PR DESCRIPTION
RedHat 7 and its derivatives are end of life and no longer supported. It may still well work as this module does not fail on unsupported platforms, though formal support is no more.